### PR TITLE
[NO MERGE] Implement full support for .NET Core 8+ and NativeAOT

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "external/DeviceIOControlLib"]
-	path = external/DeviceIOControlLib
+	path = DeviceIOControlLib
 	url = https://github.com/IsaMorphic/DeviceIOControlLib.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/DeviceIOControlLib"]
+	path = external/DeviceIOControlLib
+	url = https://github.com/IsaMorphic/DeviceIOControlLib.git

--- a/RawDiskLib.sln
+++ b/RawDiskLib.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31105.61
+# Visual Studio Version 18
+VisualStudioVersion = 18.7.11822.327 insiders
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RawDiskLib", "RawDiskLib\RawDiskLib.csproj", "{C2D3D361-FD53-4928-8467-72AAD5C63D24}"
 EndProject
@@ -20,6 +20,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_Imports", "_Imports", "{85
 		_Imports\Local.targets = _Imports\Local.targets
 		_Imports\Test.targets = _Imports\Test.targets
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeviceIOControlLib", "DeviceIOControlLib\DeviceIOControlLib\DeviceIOControlLib.csproj", "{594A0CB5-BCD6-869F-EDED-DF848149BB1B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -55,6 +57,18 @@ Global
 		{0D4905FB-6E29-4ADF-90B7-C560B962F3F0}.Release|x64.Build.0 = Release|Any CPU
 		{0D4905FB-6E29-4ADF-90B7-C560B962F3F0}.Release|x86.ActiveCfg = Release|Any CPU
 		{0D4905FB-6E29-4ADF-90B7-C560B962F3F0}.Release|x86.Build.0 = Release|Any CPU
+		{594A0CB5-BCD6-869F-EDED-DF848149BB1B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{594A0CB5-BCD6-869F-EDED-DF848149BB1B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{594A0CB5-BCD6-869F-EDED-DF848149BB1B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{594A0CB5-BCD6-869F-EDED-DF848149BB1B}.Debug|x64.Build.0 = Debug|Any CPU
+		{594A0CB5-BCD6-869F-EDED-DF848149BB1B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{594A0CB5-BCD6-869F-EDED-DF848149BB1B}.Debug|x86.Build.0 = Debug|Any CPU
+		{594A0CB5-BCD6-869F-EDED-DF848149BB1B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{594A0CB5-BCD6-869F-EDED-DF848149BB1B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{594A0CB5-BCD6-869F-EDED-DF848149BB1B}.Release|x64.ActiveCfg = Release|Any CPU
+		{594A0CB5-BCD6-869F-EDED-DF848149BB1B}.Release|x64.Build.0 = Release|Any CPU
+		{594A0CB5-BCD6-869F-EDED-DF848149BB1B}.Release|x86.ActiveCfg = Release|Any CPU
+		{594A0CB5-BCD6-869F-EDED-DF848149BB1B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RawDiskLib/RawDisk.cs
+++ b/RawDiskLib/RawDisk.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.Diagnostics;
 using System.IO;
 using DeviceIOControlLib.Objects.Disk;
@@ -214,12 +215,12 @@ namespace RawDiskLib
             return wasRead;
         }
 
-        public RawDiskStream CreateDiskStream()
+        public RawDiskStream CreateDiskStream(ArrayPool<byte> bufferArrayPool)
         {
             SafeFileHandle diskHandle = PlatformShim.CreateDeviceHandle(DosDeviceName, _access);
             FileStream diskFs = new FileStream(diskHandle, _access);
 
-            return new RawDiskStream(diskFs, SectorSize, SizeBytes);
+            return new RawDiskStream(diskFs, SectorSize, SizeBytes, bufferArrayPool);
         }
 
         public void Dispose()

--- a/RawDiskLib/RawDiskLib.csproj
+++ b/RawDiskLib/RawDiskLib.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net7.0-windows;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>Library to read and write to raw disks in Windows, something that can be tricky from time to time</Description>
     <PackageTags>Raw-disk;Disk</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DeviceIOControlLib" Version="0.1.6" />
+    <ProjectReference Include="..\external\DeviceIOControlLib\DeviceIOControlLib\DeviceIOControlLib.csproj" />
   </ItemGroup>
 
 </Project>

--- a/RawDiskLib/RawDiskLib.csproj
+++ b/RawDiskLib/RawDiskLib.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\external\DeviceIOControlLib\DeviceIOControlLib\DeviceIOControlLib.csproj" />
+    <ProjectReference Include="..\DeviceIOControlLib\DeviceIOControlLib\DeviceIOControlLib.csproj" />
   </ItemGroup>
 
 </Project>

--- a/RawDiskLib/RawDiskStream.cs
+++ b/RawDiskLib/RawDiskStream.cs
@@ -7,6 +7,13 @@ namespace RawDiskLib
 {
     public class RawDiskStream : Stream
     {
+        private class ChunkInfo 
+        {
+            public byte[] Data { get; init; }
+
+            public bool IsDirty { get; set; }
+        }
+
         private const int MAX_CACHE_SIZE_BYTES = 1024 * 1024 * 1024; // Arbitrary limit for caching
 
         private readonly FileStream _diskStream;
@@ -15,7 +22,7 @@ namespace RawDiskLib
 
         // Caching mechanism: chunk index to chunk data
         private readonly ArrayPool<byte> _bufferArrayPool;
-        private readonly SortedDictionary<long, byte[]> _chunks;
+        private readonly SortedDictionary<long, ChunkInfo> _chunks;
         private readonly Queue<long> _accesses;
 
         internal RawDiskStream(FileStream diskStream, int smallestChunkSize, long length, ArrayPool<byte> bufferArrayPool)
@@ -25,42 +32,54 @@ namespace RawDiskLib
             _length = length;
 
             _bufferArrayPool = bufferArrayPool;
-            _chunks = new SortedDictionary<long, byte[]>();
+            _chunks = new SortedDictionary<long, ChunkInfo>();
             _accesses = new Queue<long>();
         }
 
-        private byte[] GetChunk(long chunkIndex)
+        private ChunkInfo GetChunk(long chunkIndex)
         {
             // Evict least recently used chunks if cache exceeds limit
             while (Math.BigMul(_chunks.Count, _smallestChunkSize) > MAX_CACHE_SIZE_BYTES && 
                 _accesses.TryDequeue(out long oldestChunkIndex))
             {
-                _chunks.Remove(oldestChunkIndex, out byte[] oldestChunk);
-                _diskStream.Seek(oldestChunkIndex * _smallestChunkSize, SeekOrigin.Begin);
-                _diskStream.Write(oldestChunk, 0, _smallestChunkSize);
-                _bufferArrayPool.Return(oldestChunk, clearArray: true);
+                _chunks.Remove(oldestChunkIndex, out ChunkInfo oldestChunkInfo);
+                if (oldestChunkInfo.IsDirty)
+                {
+                    _diskStream.Seek(oldestChunkIndex * _smallestChunkSize, SeekOrigin.Begin);
+                    _diskStream.Write(oldestChunkInfo.Data, 0, _smallestChunkSize);
+                }
+
+                _bufferArrayPool.Return(oldestChunkInfo.Data, clearArray: true);
             }
 
-            if (!_chunks.TryGetValue(chunkIndex, out byte[] chunk))
+            if (!_chunks.TryGetValue(chunkIndex, out ChunkInfo chunkInfo))
             {
-                chunk = _bufferArrayPool.Rent(_smallestChunkSize);
-                _diskStream.Seek(chunkIndex * _smallestChunkSize, SeekOrigin.Begin);
-                _diskStream.ReadExactly(chunk, 0, _smallestChunkSize);
+                chunkInfo = new ChunkInfo
+                {
+                    Data = _bufferArrayPool.Rent(_smallestChunkSize),
+                };
 
-                _chunks.Add(chunkIndex, chunk);
+                _diskStream.Seek(chunkIndex * _smallestChunkSize, SeekOrigin.Begin);
+                _diskStream.ReadExactly(chunkInfo.Data, 0, _smallestChunkSize);
+
+                _chunks.Add(chunkIndex, chunkInfo);
                 _accesses.Enqueue(chunkIndex);
             }
 
-            return chunk;
+            return chunkInfo;
         }
 
         public override void Flush()
         {
-            foreach ((long chunkIndex, byte[] chunk) in _chunks)
+            foreach ((long chunkIndex, ChunkInfo chunkInfo) in _chunks)
             {
-                _diskStream.Seek(chunkIndex * _smallestChunkSize, SeekOrigin.Begin);
-                _diskStream.Write(chunk, 0, _smallestChunkSize);
-                _bufferArrayPool.Return(chunk, clearArray: true);
+                if (chunkInfo.IsDirty)
+                {
+                    _diskStream.Seek(chunkIndex * _smallestChunkSize, SeekOrigin.Begin);
+                    _diskStream.Write(chunkInfo.Data, 0, _smallestChunkSize);
+                }
+
+                _bufferArrayPool.Return(chunkInfo.Data, clearArray: true);
             }
 
             _chunks.Clear();
@@ -109,12 +128,12 @@ namespace RawDiskLib
             long totalRead = 0;
             while (totalRead < count && Position + totalRead < Length)
             {
-                byte[] chunk = GetChunk(chunkIndex++);
+                ChunkInfo chunkInfo = GetChunk(chunkIndex++);
 
                 long toCopy = Math.Min(_smallestChunkSize - chunkOffset, count - totalRead);
                 toCopy = Math.Min(toCopy, Length - (Position + totalRead));
 
-                Array.Copy(chunk, chunkOffset, buffer, offset + totalRead, toCopy);
+                Array.Copy(chunkInfo.Data, chunkOffset, buffer, offset + totalRead, toCopy);
                 chunkOffset = (chunkOffset + toCopy) % _smallestChunkSize;
 
                 totalRead += toCopy;
@@ -131,12 +150,13 @@ namespace RawDiskLib
             long totalWritten = 0;
             while (totalWritten < count && Position + totalWritten < Length)
             {
-                byte[] chunk = GetChunk(chunkIndex++);
+                ChunkInfo chunkInfo = GetChunk(chunkIndex++);
 
                 long toCopy = Math.Min(_smallestChunkSize - chunkOffset, count - totalWritten);
                 toCopy = Math.Min(toCopy, Length - (Position + totalWritten));
+                if(toCopy > 0) chunkInfo.IsDirty = true;
 
-                Array.Copy(buffer, offset + totalWritten, chunk, chunkOffset, toCopy);
+                Array.Copy(buffer, offset + totalWritten, chunkInfo.Data, chunkOffset, toCopy);
                 chunkOffset = (chunkOffset + toCopy) % _smallestChunkSize;
 
                 totalWritten += toCopy;

--- a/RawDiskLib/RawDiskStream.cs
+++ b/RawDiskLib/RawDiskStream.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Runtime.Intrinsics.X86;
 
 namespace RawDiskLib
 {

--- a/RawDiskLib/RawDiskStream.cs
+++ b/RawDiskLib/RawDiskStream.cs
@@ -1,26 +1,51 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
 
 namespace RawDiskLib
 {
     public class RawDiskStream : Stream
     {
+        private const int MAX_CACHE_SIZE = 1024 * 1024; // Arbitrary limit for caching
+
         private readonly FileStream _diskStream;
         private readonly int _smallestChunkSize;
-        private readonly byte[] _currentChunk;
         private readonly long _length;
 
-        private bool _didFirstRead;
+        // Caching mechanism: chunk index to chunk data
+        private readonly Dictionary<long, byte[]> _chunks;
+        private readonly Queue<long> _accesses;
 
         internal RawDiskStream(FileStream diskStream, int smallestChunkSize, long length)
         {
             _diskStream = diskStream;
             _smallestChunkSize = smallestChunkSize;
-            _currentChunk = new byte[smallestChunkSize];
             _length = length;
+
+            _chunks = new Dictionary<long, byte[]>();
+            _accesses = new Queue<long>();
+        }
+
+        private byte[] GetChunk(long chunkIndex)
+        {
+            // Evict least recently used chunks if cache exceeds limit
+            while (_chunks.Count > MAX_CACHE_SIZE)
+            {
+                long oldestChunkIndex = _accesses.Dequeue();
+                _chunks.Remove(oldestChunkIndex);
+            }
+
+            if (!_chunks.TryGetValue(chunkIndex, out byte[] chunk))
+            {
+                chunk = new byte[_smallestChunkSize];
+                _diskStream.Seek(chunkIndex * _smallestChunkSize, SeekOrigin.Begin);
+                _diskStream.ReadExactly(chunk, 0, _smallestChunkSize);
+
+                _chunks.Add(chunkIndex, chunk);
+                _accesses.Enqueue(chunkIndex);
+            }
+
+            return chunk;
         }
 
         public override void Flush()
@@ -53,14 +78,6 @@ namespace RawDiskLib
             // Valid
             Position = newPosition;
 
-            // Position disk stream
-            long diskOffset = Position - Position % _smallestChunkSize; // Align to a multiple of '_smallestChunkSize'
-
-            Debug.Assert(diskOffset % _smallestChunkSize == 0);
-
-            _diskStream.Seek(diskOffset, SeekOrigin.Begin);
-            _diskStream.ReadExactly(_currentChunk, 0, _smallestChunkSize);
-
             return Position;
         }
 
@@ -72,109 +89,53 @@ namespace RawDiskLib
         public override int Read(byte[] buffer, int offset, int count)
         {
             (long chunkIndex, long chunkOffset) = Math.DivRem(Position, _smallestChunkSize);
+            byte[] chunk = GetChunk(chunkIndex);
 
-            // Seek
-            long diskOffset = chunkIndex * _smallestChunkSize;
-            if (diskOffset != _diskStream.Position || !_didFirstRead)
+            long totalRead = 0;
+            while (totalRead < count && Position + totalRead < Length)
             {
-                _diskStream.Seek(diskOffset, SeekOrigin.Begin);
-                _diskStream.ReadExactly(_currentChunk, 0, _smallestChunkSize);
-                _didFirstRead = true;
-            }
-
-            int totalRead = 0;
-            while (totalRead < count)
-            {
-                if (chunkOffset >= _smallestChunkSize) 
+                if (chunkOffset >= _smallestChunkSize)
                 {
-                    _diskStream.Seek(++chunkIndex * _smallestChunkSize, SeekOrigin.Begin);
-                    _diskStream.ReadExactly(_currentChunk, 0, _smallestChunkSize);
+                    chunk = GetChunk(++chunkIndex);
                     chunkOffset -= _smallestChunkSize;
                 }
 
-                int toCopy = (int)((IEnumerable<long>)[_smallestChunkSize - chunkOffset, count - totalRead, Length - (Position + totalRead)]).Min();
-                Array.Copy(_currentChunk, chunkOffset, buffer, offset + totalRead, toCopy);
+                long toCopy = Math.Min(_smallestChunkSize - chunkOffset, count - totalRead);
+                toCopy = Math.Min(toCopy, Length - (Position + totalRead));
+
+                Array.Copy(chunk, chunkOffset, buffer, offset + totalRead, toCopy);
 
                 chunkOffset += toCopy;
                 totalRead += toCopy;
             }
 
             Position += totalRead;
-            return totalRead;
+            return (int)totalRead;
         }
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            long chunk = Position / _smallestChunkSize;
-            int chunks = count / _smallestChunkSize + (Position % _smallestChunkSize == 0 ? 0 : 1);
+            throw new NotSupportedException();
+        }
 
-            // Write sectors
-            if (Position % _smallestChunkSize == 0 && count % _smallestChunkSize == 0)
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing)
             {
-                // Seek
-                long diskOffset = chunk * _smallestChunkSize;
-                if (diskOffset != _diskStream.Position)
-                    _diskStream.Seek(diskOffset, SeekOrigin.Begin);
+                _diskStream.Dispose();
 
-                // Write directly into stream
-                _diskStream.Write(buffer, offset, count);
+                _chunks.Clear();
+                _accesses.Clear();
             }
-            else
-            {
-                // Do copy-on write
-                byte[] tmpBuff = new byte[_smallestChunkSize];
-
-                int firstChunkLength = _smallestChunkSize - (int)(Position % _smallestChunkSize);
-                int middleChunksLength = ((count - firstChunkLength) / _smallestChunkSize) * _smallestChunkSize;        // This will ensure that 'middleChunksLength' is a multiple of '_smallestChunkSize'
-                int lastChunkLength = count - middleChunksLength - firstChunkLength;
-
-                Debug.Assert(0 <= firstChunkLength && firstChunkLength < _smallestChunkSize);
-                Debug.Assert(middleChunksLength % _smallestChunkSize == 0);
-                Debug.Assert(0 <= lastChunkLength && lastChunkLength < _smallestChunkSize);
-
-                // Seek
-                _diskStream.Seek(chunk * _smallestChunkSize, SeekOrigin.Begin);
-
-                // == First chunk ==
-                if (firstChunkLength > 0)
-                {
-                    // Do copy-on write
-                    _diskStream.Read(tmpBuff, 0, tmpBuff.Length);
-
-                    Array.Copy(buffer, offset, tmpBuff, tmpBuff.Length - firstChunkLength, firstChunkLength);
-
-                    _diskStream.Seek(-tmpBuff.Length, SeekOrigin.Current);
-                    _diskStream.Write(tmpBuff, 0, tmpBuff.Length);
-                }
-
-                // == Middle chunks ==
-                if (middleChunksLength > 0)
-                {
-                    // Write directly
-                    _diskStream.Write(buffer, offset + firstChunkLength, middleChunksLength);
-                }
-
-                // == Last chunk ==
-                if (lastChunkLength > 0)
-                {
-                    // Do copy-on write
-                    _diskStream.Read(tmpBuff, 0, tmpBuff.Length);
-
-                    Array.Copy(buffer, offset + firstChunkLength + middleChunksLength, tmpBuff, 0, lastChunkLength);
-
-                    _diskStream.Seek(-tmpBuff.Length, SeekOrigin.Current);
-                    _diskStream.Write(tmpBuff, 0, tmpBuff.Length);
-                }
-            }
-
-            Position += count;
         }
 
         public override bool CanRead => _diskStream.CanRead;
 
         public override bool CanSeek => _diskStream.CanSeek;
 
-        public override bool CanWrite => _diskStream.CanWrite;
+        public override bool CanWrite => false;
 
         public override long Length => _length;
 

--- a/RawDiskLib/RawDiskStream.cs
+++ b/RawDiskLib/RawDiskStream.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 
@@ -13,15 +14,17 @@ namespace RawDiskLib
         private readonly long _length;
 
         // Caching mechanism: chunk index to chunk data
+        private readonly ArrayPool<byte> _bufferArrayPool;
         private readonly Dictionary<long, byte[]> _chunks;
         private readonly Queue<long> _accesses;
 
-        internal RawDiskStream(FileStream diskStream, int smallestChunkSize, long length)
+        internal RawDiskStream(FileStream diskStream, int smallestChunkSize, long length, ArrayPool<byte> bufferArrayPool)
         {
             _diskStream = diskStream;
             _smallestChunkSize = smallestChunkSize;
             _length = length;
 
+            _bufferArrayPool = bufferArrayPool;
             _chunks = new Dictionary<long, byte[]>();
             _accesses = new Queue<long>();
         }
@@ -32,12 +35,13 @@ namespace RawDiskLib
             while (Math.BigMul(_chunks.Count, _smallestChunkSize) > MAX_CACHE_SIZE_BYTES && 
                 _accesses.TryDequeue(out long oldestChunkIndex))
             {
-                _chunks.Remove(oldestChunkIndex);
+                _chunks.Remove(oldestChunkIndex, out byte[] oldestChunk);
+                _bufferArrayPool.Return(oldestChunk, clearArray: true);
             }
 
             if (!_chunks.TryGetValue(chunkIndex, out byte[] chunk))
             {
-                chunk = new byte[_smallestChunkSize];
+                chunk = _bufferArrayPool.Rent(_smallestChunkSize);
                 _diskStream.Seek(chunkIndex * _smallestChunkSize, SeekOrigin.Begin);
                 _diskStream.ReadExactly(chunk, 0, _smallestChunkSize);
 

--- a/RawDiskLib/RawDiskStream.cs
+++ b/RawDiskLib/RawDiskStream.cs
@@ -88,8 +88,8 @@ namespace RawDiskLib
                 Array.Copy(data, (int) (Position % _smallestChunkSize), buffer, offset, count);
             }
 
-            Position += actualRead;
-            return actualRead;
+            Position += Math.Min(actualRead, count);
+            return Math.Min(actualRead, count);
         }
 
         public override void Write(byte[] buffer, int offset, int count)

--- a/RawDiskLib/RawDiskStream.cs
+++ b/RawDiskLib/RawDiskStream.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
+using System.Runtime.Intrinsics.X86;
 
 namespace RawDiskLib
 {
@@ -8,12 +11,16 @@ namespace RawDiskLib
     {
         private readonly FileStream _diskStream;
         private readonly int _smallestChunkSize;
+        private readonly byte[] _currentChunk;
         private readonly long _length;
+
+        private bool _didFirstRead;
 
         internal RawDiskStream(FileStream diskStream, int smallestChunkSize, long length)
         {
             _diskStream = diskStream;
             _smallestChunkSize = smallestChunkSize;
+            _currentChunk = new byte[smallestChunkSize];
             _length = length;
         }
 
@@ -53,6 +60,7 @@ namespace RawDiskLib
             Debug.Assert(diskOffset % _smallestChunkSize == 0);
 
             _diskStream.Seek(diskOffset, SeekOrigin.Begin);
+            _ = _diskStream.Read(_currentChunk, 0, _smallestChunkSize);
 
             return Position;
         }
@@ -64,32 +72,36 @@ namespace RawDiskLib
 
         public override int Read(byte[] buffer, int offset, int count)
         {
-            long chunk = Position / _smallestChunkSize;
-            int chunks = count / _smallestChunkSize + (Position % _smallestChunkSize == 0 ? 0 : 1);
+            (long chunkIndex, long chunkOffset) = Math.DivRem(Position, _smallestChunkSize);
 
             // Seek
-            long diskOffset = chunk * _smallestChunkSize;
-            if (diskOffset != _diskStream.Position)
+            long diskOffset = chunkIndex * _smallestChunkSize;
+            if (diskOffset != _diskStream.Position || !_didFirstRead)
+            {
                 _diskStream.Seek(diskOffset, SeekOrigin.Begin);
-
-            // Read sectors
-            int actualRead;
-            if (Position % _smallestChunkSize == 0 && count % _smallestChunkSize == 0)
-            {
-                // Read directly into target buffer
-                actualRead = _diskStream.Read(buffer, offset, count);
-            }
-            else
-            {
-                // Do a temporary buffer
-                byte[] data = new byte[(chunks + 1) * _smallestChunkSize];
-               actualRead= _diskStream.Read(data, 0, data.Length);
-
-                Array.Copy(data, (int) (Position % _smallestChunkSize), buffer, offset, count);
+                _ = _diskStream.Read(_currentChunk, 0, _smallestChunkSize);
+                _didFirstRead = true;
             }
 
-            Position += Math.Min(actualRead, count);
-            return Math.Min(actualRead, count);
+            int totalRead = 0;
+            while (totalRead < count)
+            {
+                if (chunkOffset >= _smallestChunkSize) 
+                {
+                    _diskStream.Seek(++chunkIndex * _smallestChunkSize, SeekOrigin.Begin);
+                    _ = _diskStream.Read(_currentChunk, 0, _smallestChunkSize);
+                    chunkOffset -= _smallestChunkSize;
+                }
+
+                int toCopy = (int)((IEnumerable<long>)[_smallestChunkSize - chunkOffset, count - totalRead, Length - (Position + totalRead)]).Min();
+                Array.Copy(_currentChunk, chunkOffset, buffer, offset + totalRead, toCopy);
+
+                chunkOffset += toCopy;
+                totalRead += toCopy;
+            }
+
+            Position += totalRead;
+            return totalRead;
         }
 
         public override void Write(byte[] buffer, int offset, int count)

--- a/RawDiskLib/RawDiskStream.cs
+++ b/RawDiskLib/RawDiskStream.cs
@@ -15,7 +15,7 @@ namespace RawDiskLib
 
         // Caching mechanism: chunk index to chunk data
         private readonly ArrayPool<byte> _bufferArrayPool;
-        private readonly Dictionary<long, byte[]> _chunks;
+        private readonly SortedDictionary<long, byte[]> _chunks;
         private readonly Queue<long> _accesses;
 
         internal RawDiskStream(FileStream diskStream, int smallestChunkSize, long length, ArrayPool<byte> bufferArrayPool)
@@ -25,7 +25,7 @@ namespace RawDiskLib
             _length = length;
 
             _bufferArrayPool = bufferArrayPool;
-            _chunks = new Dictionary<long, byte[]>();
+            _chunks = new SortedDictionary<long, byte[]>();
             _accesses = new Queue<long>();
         }
 
@@ -36,6 +36,8 @@ namespace RawDiskLib
                 _accesses.TryDequeue(out long oldestChunkIndex))
             {
                 _chunks.Remove(oldestChunkIndex, out byte[] oldestChunk);
+                _diskStream.Seek(oldestChunkIndex * _smallestChunkSize, SeekOrigin.Begin);
+                _diskStream.Write(oldestChunk, 0, _smallestChunkSize);
                 _bufferArrayPool.Return(oldestChunk, clearArray: true);
             }
 
@@ -54,6 +56,16 @@ namespace RawDiskLib
 
         public override void Flush()
         {
+            foreach ((long chunkIndex, byte[] chunk) in _chunks)
+            {
+                _diskStream.Seek(chunkIndex * _smallestChunkSize, SeekOrigin.Begin);
+                _diskStream.Write(chunk, 0, _smallestChunkSize);
+                _bufferArrayPool.Return(chunk, clearArray: true);
+            }
+
+            _chunks.Clear();
+            _accesses.Clear();
+
             _diskStream.Flush();
         }
 
@@ -114,7 +126,23 @@ namespace RawDiskLib
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            throw new NotSupportedException();
+            (long chunkIndex, long chunkOffset) = Math.DivRem(Position, _smallestChunkSize);
+
+            long totalWritten = 0;
+            while (totalWritten < count && Position + totalWritten < Length)
+            {
+                byte[] chunk = GetChunk(chunkIndex++);
+
+                long toCopy = Math.Min(_smallestChunkSize - chunkOffset, count - totalWritten);
+                toCopy = Math.Min(toCopy, Length - (Position + totalWritten));
+
+                Array.Copy(buffer, offset + totalWritten, chunk, chunkOffset, toCopy);
+                chunkOffset = (chunkOffset + toCopy) % _smallestChunkSize;
+
+                totalWritten += toCopy;
+            }
+
+            Position += totalWritten;
         }
 
         protected override void Dispose(bool disposing)
@@ -123,15 +151,7 @@ namespace RawDiskLib
 
             if (disposing)
             {
-                foreach ((long _, byte[] chunk) in _chunks)
-                {
-                    _bufferArrayPool.Return(chunk, clearArray: true);
-                }
-
-                _chunks.Clear();
-                _accesses.Clear();
-
-                _diskStream.Dispose();
+                Flush(); _diskStream.Dispose();
             }
         }
 
@@ -139,7 +159,7 @@ namespace RawDiskLib
 
         public override bool CanSeek => _diskStream.CanSeek;
 
-        public override bool CanWrite => false;
+        public override bool CanWrite => _diskStream.CanWrite;
 
         public override long Length => _length;
 

--- a/RawDiskLib/RawDiskStream.cs
+++ b/RawDiskLib/RawDiskStream.cs
@@ -59,7 +59,7 @@ namespace RawDiskLib
             Debug.Assert(diskOffset % _smallestChunkSize == 0);
 
             _diskStream.Seek(diskOffset, SeekOrigin.Begin);
-            _ = _diskStream.Read(_currentChunk, 0, _smallestChunkSize);
+            _diskStream.ReadExactly(_currentChunk, 0, _smallestChunkSize);
 
             return Position;
         }
@@ -78,7 +78,7 @@ namespace RawDiskLib
             if (diskOffset != _diskStream.Position || !_didFirstRead)
             {
                 _diskStream.Seek(diskOffset, SeekOrigin.Begin);
-                _ = _diskStream.Read(_currentChunk, 0, _smallestChunkSize);
+                _diskStream.ReadExactly(_currentChunk, 0, _smallestChunkSize);
                 _didFirstRead = true;
             }
 
@@ -88,7 +88,7 @@ namespace RawDiskLib
                 if (chunkOffset >= _smallestChunkSize) 
                 {
                     _diskStream.Seek(++chunkIndex * _smallestChunkSize, SeekOrigin.Begin);
-                    _ = _diskStream.Read(_currentChunk, 0, _smallestChunkSize);
+                    _diskStream.ReadExactly(_currentChunk, 0, _smallestChunkSize);
                     chunkOffset -= _smallestChunkSize;
                 }
 

--- a/RawDiskLib/RawDiskStream.cs
+++ b/RawDiskLib/RawDiskStream.cs
@@ -6,7 +6,7 @@ namespace RawDiskLib
 {
     public class RawDiskStream : Stream
     {
-        private const int MAX_CACHE_SIZE = 1024 * 1024; // Arbitrary limit for caching
+        private const int MAX_CACHE_SIZE_BYTES = 1024 * 1024 * 1024; // Arbitrary limit for caching
 
         private readonly FileStream _diskStream;
         private readonly int _smallestChunkSize;
@@ -29,7 +29,7 @@ namespace RawDiskLib
         private byte[] GetChunk(long chunkIndex)
         {
             // Evict least recently used chunks if cache exceeds limit
-            while (_chunks.Count > MAX_CACHE_SIZE)
+            while (Math.BigMul(_chunks.Count, _smallestChunkSize) > MAX_CACHE_SIZE_BYTES)
             {
                 long oldestChunkIndex = _accesses.Dequeue();
                 _chunks.Remove(oldestChunkIndex);

--- a/RawDiskLib/RawDiskStream.cs
+++ b/RawDiskLib/RawDiskStream.cs
@@ -29,9 +29,9 @@ namespace RawDiskLib
         private byte[] GetChunk(long chunkIndex)
         {
             // Evict least recently used chunks if cache exceeds limit
-            while (Math.BigMul(_chunks.Count, _smallestChunkSize) > MAX_CACHE_SIZE_BYTES)
+            while (Math.BigMul(_chunks.Count, _smallestChunkSize) > MAX_CACHE_SIZE_BYTES && 
+                _accesses.TryDequeue(out long oldestChunkIndex))
             {
-                long oldestChunkIndex = _accesses.Dequeue();
                 _chunks.Remove(oldestChunkIndex);
             }
 
@@ -89,23 +89,18 @@ namespace RawDiskLib
         public override int Read(byte[] buffer, int offset, int count)
         {
             (long chunkIndex, long chunkOffset) = Math.DivRem(Position, _smallestChunkSize);
-            byte[] chunk = GetChunk(chunkIndex);
 
             long totalRead = 0;
             while (totalRead < count && Position + totalRead < Length)
             {
-                if (chunkOffset >= _smallestChunkSize)
-                {
-                    chunk = GetChunk(++chunkIndex);
-                    chunkOffset -= _smallestChunkSize;
-                }
+                byte[] chunk = GetChunk(chunkIndex++);
 
                 long toCopy = Math.Min(_smallestChunkSize - chunkOffset, count - totalRead);
                 toCopy = Math.Min(toCopy, Length - (Position + totalRead));
 
                 Array.Copy(chunk, chunkOffset, buffer, offset + totalRead, toCopy);
+                chunkOffset = (chunkOffset + toCopy) % _smallestChunkSize;
 
-                chunkOffset += toCopy;
                 totalRead += toCopy;
             }
 

--- a/RawDiskLib/RawDiskStream.cs
+++ b/RawDiskLib/RawDiskStream.cs
@@ -123,10 +123,15 @@ namespace RawDiskLib
 
             if (disposing)
             {
-                _diskStream.Dispose();
+                foreach ((long _, byte[] chunk) in _chunks)
+                {
+                    _bufferArrayPool.Return(chunk, clearArray: true);
+                }
 
                 _chunks.Clear();
                 _accesses.Clear();
+
+                _diskStream.Dispose();
             }
         }
 


### PR DESCRIPTION
This PR is not meant to be merged, but it is a notice to the maintainer of RawDiskLib, and anyone that comes across the project, that I've created a special fork of the library that is meant to better support NativeAOT features in .NET 8 and above. This patch also adds my fork of DiskIOControlLib as a submodule containing similar fixes and adaptations. Additionally, this version of the fork supports memory caching for `RawDiskStream`.

Thank you, and enjoy!